### PR TITLE
Tests/indexer

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/GeneralTesting.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/GeneralTesting.cpp
@@ -284,8 +284,8 @@ void AGeneralTesting::TestHistory() const
 		FSeqGetTransactionHistoryArgs args;
 		args.filter.accountAddress = Api->GetWalletAddress();
 		args.includeMetaData = true;
-		args.page.page = 0;
-		args.page.more = true;
+		args.page->page = 0;
+		args.page->more = true;
 		Api->GetTransactionHistory(args,GenericSuccess,GenericFailure);
 	}
 }

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Tests/IndexerTests.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Tests/IndexerTests.cpp
@@ -218,8 +218,8 @@ void GetTransactionHistoryTest(UIndexer* Indexer, TFunction<void(FString)> OnSuc
 	FSeqGetTransactionHistoryArgs Args;
 	Args.filter.accountAddress = "0x0E0f9d1c4BeF9f0B8a2D9D4c09529F260C7758A2";
 	Args.includeMetaData = true;
-	Args.page.page = 0;
-	Args.page.more = true;
+	Args.page->page = 0;
+	Args.page->more = true;
 	Indexer->GetTransactionHistory(GTestingChainID, Args, GenericSuccess, GenericFailure);
 }
 

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTokenSuppliesArgs.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTokenSuppliesArgs.h
@@ -15,8 +15,26 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
         bool includeMetaData = false;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
-        FSeqPage page;
+        TOptional<FSeqPage> page;
 
-    bool customGetter = false;
-    FString GetArgs() { return ""; }//no custom getter needed here!
+    bool customGetter = true;
+    FString GetArgs() { 
+        TSharedPtr<FJsonObject> JsonObject = MakeShared<FJsonObject>();
+    
+        JsonObject->SetStringField("contractAddress", contractAddress);
+        JsonObject->SetBoolField("includeMetaData", includeMetaData);
+    
+        if (page.IsSet())
+        {
+            TSharedPtr<FJsonObject> PageObject = MakeShared<FJsonObject>();
+            FJsonObjectConverter::UStructToJsonObject(FSeqPage::StaticStruct(), &(page.GetValue()), PageObject.ToSharedRef(), 0, 0);
+            JsonObject->SetObjectField("page", PageObject);
+        }
+
+        FString OutputString = "";
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
+        FJsonSerializer::Serialize(JsonObject.ToSharedRef(), Writer);
+
+        return OutputString;
+    }
 };

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTokenSuppliesMapArgs.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTokenSuppliesMapArgs.h
@@ -57,8 +57,9 @@ public:
 
 		for (FString key : keys)
 		{
-			ret += "\"" + key + "\":" + USequenceSupport::StringListToParsableString(tokenMap.Find(key)->token_list);
+			ret += "\"" + key + "\":" + USequenceSupport::StringListToParsableString(tokenMap.Find(key)->token_list) + ",";
 		}
+		ret = ret.LeftChop(1); //remove the last comma
 		ret += "},";//close off tokenMap subObject
 		ret += "\"includeMetaData\":";
 		ret += includeMetaData ? "true" : "false";

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTransactionHistoryArgs.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqGetTransactionHistoryArgs.h
@@ -14,24 +14,23 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
         FSeqTransactionHistoryFilter filter;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
-        FSeqPage page;
+        TOptional<FSeqPage> page;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
         bool includeMetaData = false;
 
     bool customGetter = true;
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <returns>The jsonString from this UStruct formatted proper!</returns>
     FString GetArgs()
     {
         FString ret = "{";
         ret.Append("\"filter\":");
         ret.Append(filter.GetArgs());//get the args! MUST Have this!
-        if (page.containsData())
+        if (page.IsSet())
         {
-            ret.Append(",\"page\":");
-            ret.Append(page.GetArgs());
+            ret.Append(".\"page\":");
+            ret.Append(page.GetValue().GetArgs());
+            TSharedPtr<FJsonObject> PageObject = MakeShared<FJsonObject>();
+            FJsonObjectConverter::UStructToJsonObject(FSeqPage::StaticStruct(), &(page.GetValue()), PageObject.ToSharedRef(), 0, 0);
+            
         }
 
         ret.Append(",\"includeMetaData\":");

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqTokenList.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Indexer/Structs/SeqTokenList.h
@@ -9,12 +9,31 @@
     in UStructs allowing us to support nesting
 */
 
-//For use in GetTokenSuppliesMapArgs
+// For use in GetTokenSuppliesMapArgs
 USTRUCT(BlueprintType)
 struct SEQUENCEPLUGIN_API FSeqTokenList
 {
     GENERATED_USTRUCT_BODY()
+
 public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
-        TArray<FString> token_list;
+    TArray<FString> token_list;
+
+    // Default constructor
+    FSeqTokenList() {}
+
+    // Constructor to initialize with a variadic list of FString arguments
+    template<typename... Args>
+    FSeqTokenList(Args... args)
+    {
+        AddTokens(args...);
+    }
+
+private:
+    // Helper function to unpack variadic arguments and add them to the token_list
+    template<typename... Args>
+    void AddTokens(Args... args)
+    {
+        token_list = { args... };
+    }
 };

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/Helpers/IndexerEndToEndTestsCommon.h
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/Helpers/IndexerEndToEndTestsCommon.h
@@ -9,4 +9,6 @@ namespace IndexerEndToEndTestsCommon
 	const FString TestAddress = TEXT("0x8e3E38fe7367dd3b52D1e281E4e8400447C8d8B9"); // From the Sequence Docs - this address has a fair amount of tokens held on Polygon and works great for our test cases
 	const int64 PolygonNetworkId = 137;
 	const FString TestContractAddress_Skyweaver = TEXT("0x631998e91476DA5B870D741192fc5Cbc55F5a52E");
+	const FString TestContractAddress_USDC = TEXT("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359");
+	const FString TestContractAddress_WMATIC = TEXT("0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270");
 }

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/Helpers/IndexerEndToEndTestsCommon.h
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/Helpers/IndexerEndToEndTestsCommon.h
@@ -7,5 +7,6 @@
 namespace IndexerEndToEndTestsCommon
 {
 	const FString TestAddress = TEXT("0x8e3E38fe7367dd3b52D1e281E4e8400447C8d8B9"); // From the Sequence Docs - this address has a fair amount of tokens held on Polygon and works great for our test cases
-	const int64 PolygonNetworkId = 137; 
+	const int64 PolygonNetworkId = 137;
+	const FString TestContractAddress_Skyweaver = TEXT("0x631998e91476DA5B870D741192fc5Cbc55F5a52E");
 }

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenBalancesAsMapTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenBalancesAsMapTest.cpp
@@ -1,0 +1,77 @@
+// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
+
+#include "CoreMinimal.h"
+#include "Helpers/IndexerEndToEndTestsCommon.h"
+#include "Misc/AutomationTest.h"
+#include "Util/Async.h"
+#include "Util/SequenceSupport.h"
+#include "Helpers/IndexerRequestsTestData.h"
+
+IMPLEMENT_COMPLEX_AUTOMATION_TEST(FIndexerGetTokenBalancesOrganizedInMapTest, "SequencePlugin.EndToEnd.IndexerTests.GetTokenBalancesOrganizedInMapTest", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+/* Latent command used to poll off main thread to see if our requests are done */
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FIsDoneGetTokenBalancesOrganizedInMap, const UIndexerRequestsTestData *, IndexerRequestsTestData, FAutomationTestBase *, GetTokenBalancesOrganizedInMapTest);
+
+bool FIsDoneGetTokenBalancesOrganizedInMap::Update()
+{
+    while(this->IndexerRequestsTestData->GetPendingRequests() > 0)
+    {
+        return false;
+    }
+
+    if (this->IndexerRequestsTestData->GetAllRequestsSuccessful())
+    {
+        GetTokenBalancesOrganizedInMapTest->AddInfo(TEXT("GetTokenBalancesOrganizedInMap request completed"));
+    }
+    else
+    {
+        GetTokenBalancesOrganizedInMapTest->AddError(FString::Printf(TEXT("GetTokenBalancesOrganizedInMap request failed")));
+    }
+    
+    return true;
+}
+
+void FIndexerGetTokenBalancesOrganizedInMapTest::GetTests(TArray<FString>& OutBeautifiedNames, TArray<FString>& OutTestCommands) const
+{
+    OutBeautifiedNames.Add(TEXT("Indexer Get Token Balances Organized In Map Test"));
+    OutTestCommands.Add(TEXT(""));
+}
+
+bool FIndexerGetTokenBalancesOrganizedInMapTest::RunTest(const FString& Parameters)
+{
+    const int64 PolygonNetworkId = IndexerEndToEndTestsCommon::PolygonNetworkId;
+    const FString& TestAddress = IndexerEndToEndTestsCommon::TestAddress;
+    UIndexerRequestsTestData * IndexerRequestsTestData = UIndexerRequestsTestData::Make(1);
+
+    const TSuccessCallback<FSeqGetTokenBalancesReturn> GenericSuccess = [this, IndexerRequestsTestData](const FSeqGetTokenBalancesReturn& TokenBalances)
+    {
+        TestNotNull(TEXT("TokenBalances"), &TokenBalances);
+        TestNotNull(TEXT("TokenBalances.page"), &TokenBalances.page);
+        TestNotNull(TEXT("TokenBalances.balances"), &TokenBalances.balances);
+        TestTrue(TEXT("TokenBalances.balances should not be empty"), TokenBalances.balances.Num() > 0);
+
+        TMap<int64, FSeqTokenBalance> TokenBalanceMap = UIndexer::GetTokenBalancesAsMap(TokenBalances.balances);
+        
+        TestNotNull(TEXT("TokenBalanceMap"), &TokenBalanceMap);
+        TestTrue(TEXT("TokenBalanceMap should not be empty"), TokenBalanceMap.Num() > 0);
+
+        const FString Message = "GetTokenBalancesOrganizedInMap request succeeded";
+        AddInfo(FString::Printf(TEXT("%s. Remaining Requests: %d"), *Message, IndexerRequestsTestData->DecrementPendingRequests()));
+    };
+
+    const FFailureCallback GenericFailure = [this, IndexerRequestsTestData](const FSequenceError& Error)
+    {
+        const FString Message = "Request Failure";
+        AddError(FString::Printf(TEXT("%s: %s. Remaining requests: %d"), *Message, *Error.Message, IndexerRequestsTestData->DecrementPendingRequests()));
+        IndexerRequestsTestData->RequestFailed();
+    };
+
+    AddInfo(FString::Printf(TEXT("Starting GetTokenBalancesOrganizedInMap request")));
+
+    FSeqGetTokenBalancesArgs Args;
+    Args.accountAddress = TestAddress;
+    IndexerRequestsTestData->GetIndexer()->GetTokenBalances(PolygonNetworkId, Args, GenericSuccess, GenericFailure);
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FIsDoneGetTokenBalancesOrganizedInMap(IndexerRequestsTestData, this));
+    return true;
+}

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenSuppliesMapTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenSuppliesMapTest.cpp
@@ -1,0 +1,98 @@
+// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
+
+#include "CoreMinimal.h"
+#include "Helpers/IndexerEndToEndTestsCommon.h"
+#include "Misc/AutomationTest.h"
+#include "Util/Async.h"
+#include "Util/SequenceSupport.h"
+#include "Helpers/IndexerRequestsTestData.h"
+
+IMPLEMENT_COMPLEX_AUTOMATION_TEST(FIndexerGetTokenSuppliesMapTest, "SequencePlugin.EndToEnd.IndexerTests.GetTokenSuppliesMapTest", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FIsDoneGetTokenSuppliesMap, const UIndexerRequestsTestData *, IndexerRequestsTestData, FAutomationTestBase *, GetTokenSuppliesMapTest);
+
+bool FIsDoneGetTokenSuppliesMap::Update()
+{
+    if (IndexerRequestsTestData->GetPendingRequests() == 0)
+    {
+        if (IndexerRequestsTestData->GetAllRequestsSuccessful())
+        {
+            GetTokenSuppliesMapTest->AddInfo(TEXT("GetTokenSuppliesMap request completed"));
+        }
+        else
+        {
+            GetTokenSuppliesMapTest->AddError(TEXT("GetTokenSuppliesMap request failed"));
+        }
+        return true;
+    }
+    return false;
+}
+
+void FIndexerGetTokenSuppliesMapTest::GetTests(TArray<FString>& OutBeautifiedNames, TArray<FString>& OutTestCommands) const
+{
+    OutBeautifiedNames.Add(TEXT("Indexer Get Token Supplies Map Test"));
+    OutTestCommands.Add(TEXT(""));
+}
+
+bool FIndexerGetTokenSuppliesMapTest::RunTest(const FString& Parameters)
+{
+    const int64 PolygonNetworkId = IndexerEndToEndTestsCommon::PolygonNetworkId;
+    UIndexerRequestsTestData* IndexerRequestsTestData = UIndexerRequestsTestData::Make(1);
+
+    const FString UsdcAddress = IndexerEndToEndTestsCommon::TestContractAddress_USDC;
+    const FString WmaticAddress = IndexerEndToEndTestsCommon::TestContractAddress_WMATIC;
+    const FString SkyweaverAddress = IndexerEndToEndTestsCommon::TestContractAddress_Skyweaver;
+    const FString SkyweaverTokenId1 = "68657";
+    const FString SkyweaverTokenId2 = "66669";
+    const FString SkyweaverTokenId3 = "66668";
+
+    const TSuccessCallback<FSeqGetTokenSuppliesMapReturn> GenericSuccess = [this, IndexerRequestsTestData, UsdcAddress, WmaticAddress, SkyweaverAddress, SkyweaverTokenId1, SkyweaverTokenId2, SkyweaverTokenId3](const FSeqGetTokenSuppliesMapReturn& SuppliesMap)
+    {
+        TestNotNull(TEXT("SuppliesMap"), &SuppliesMap);
+        TestNotNull(TEXT("SuppliesMap.supplies"), &SuppliesMap.supplies);
+        TestEqual(TEXT("SuppliesMap.supplies count"), SuppliesMap.supplies.Num(), 3);
+        TestTrue(TEXT("SuppliesMap contains USDC"), SuppliesMap.supplies.Contains(UsdcAddress));
+        TestTrue(TEXT("SuppliesMap contains WMATIC"), SuppliesMap.supplies.Contains(WmaticAddress));
+        TestTrue(TEXT("SuppliesMap contains Skyweaver"), SuppliesMap.supplies.Contains(SkyweaverAddress));
+
+        const FSeqTokenSupplyList* UsdcSupplies = SuppliesMap.supplies.Find(UsdcAddress);
+        const FSeqTokenSupplyList* WmaticSupplies = SuppliesMap.supplies.Find(WmaticAddress);
+        const FSeqTokenSupplyList* SkyweaverSupplies = SuppliesMap.supplies.Find(SkyweaverAddress);
+
+        TestNotNull(TEXT("USDC Supplies"), UsdcSupplies);
+        TestNotNull(TEXT("WMATIC Supplies"), WmaticSupplies);
+        TestNotNull(TEXT("Skyweaver Supplies"), SkyweaverSupplies);
+
+        TestEqual(TEXT("USDC Supplies count"), UsdcSupplies->token_supply_list.Num(), 1);
+        TestEqual(TEXT("WMATIC Supplies count"), WmaticSupplies->token_supply_list.Num(), 1);
+        TestEqual(TEXT("Skyweaver Supplies count"), SkyweaverSupplies->token_supply_list.Num(), 3);
+
+        TestTrue(TEXT("USDC supply length > 0"), UsdcSupplies->token_supply_list[0].supply.Len() > 0);
+        TestTrue(TEXT("WMATIC supply length > 0"), WmaticSupplies->token_supply_list[0].supply.Len() > 0);
+        TestTrue(TEXT("Skyweaver supply 1 length > 0"), SkyweaverSupplies->token_supply_list[0].supply.Len() > 0);
+        TestTrue(TEXT("Skyweaver supply 2 length > 0"), SkyweaverSupplies->token_supply_list[1].supply.Len() > 0);
+        TestTrue(TEXT("Skyweaver supply 3 length > 0"), SkyweaverSupplies->token_supply_list[2].supply.Len() > 0);
+
+        const FString Message = "GetTokenSuppliesMap request succeeded";
+        AddInfo(FString::Printf(TEXT("%s. Remaining Requests: %d"), *Message, IndexerRequestsTestData->DecrementPendingRequests()));
+    };
+
+    const FFailureCallback GenericFailure = [this, IndexerRequestsTestData](const FSequenceError& Error)
+    {
+        const FString Message = "GetTokenSuppliesMap Request Failure";
+        AddError(FString::Printf(TEXT("%s: %s. Remaining requests: %d"), *Message, *Error.Message, IndexerRequestsTestData->DecrementPendingRequests()));
+        IndexerRequestsTestData->RequestFailed();
+    };
+
+    AddInfo(TEXT("Starting GetTokenSuppliesMap request"));
+
+    FSeqGetTokenSuppliesMapArgs Args;
+    Args.tokenMap.Add(UsdcAddress, FSeqTokenList());
+    Args.tokenMap.Add(WmaticAddress, FSeqTokenList("0"));
+    Args.tokenMap.Add(SkyweaverAddress, FSeqTokenList(SkyweaverTokenId1, SkyweaverTokenId2, SkyweaverTokenId3));
+
+    IndexerRequestsTestData->GetIndexer()->GetTokenSuppliesMap(PolygonNetworkId, Args, GenericSuccess, GenericFailure);
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FIsDoneGetTokenSuppliesMap(IndexerRequestsTestData, this));
+    return true;
+}

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenSuppliesTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTokenSuppliesTest.cpp
@@ -1,0 +1,73 @@
+// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
+
+#include "CoreMinimal.h"
+#include "Helpers/IndexerEndToEndTestsCommon.h"
+#include "Misc/AutomationTest.h"
+#include "Util/Async.h"
+#include "Util/SequenceSupport.h"
+#include "Helpers/IndexerRequestsTestData.h"
+
+IMPLEMENT_COMPLEX_AUTOMATION_TEST(FIndexerGetTokenSuppliesTest, "SequencePlugin.EndToEnd.IndexerTests.GetTokenSuppliesTest", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+/* Latent command used to poll off main thread to see if our requests are done */
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FIsDoneGetTokenSupplies, const UIndexerRequestsTestData *, IndexerRequestsTestData, FAutomationTestBase *, GetTokenSuppliesTest);
+
+bool FIsDoneGetTokenSupplies::Update()
+{
+    while(this->IndexerRequestsTestData->GetPendingRequests() > 0)
+    {
+        return false;
+    }
+
+    if (this->IndexerRequestsTestData->GetAllRequestsSuccessful())
+    {
+        GetTokenSuppliesTest->AddInfo(TEXT("GetTokenSupplies request completed"));
+    }
+    else
+    {
+        GetTokenSuppliesTest->AddError(FString::Printf(TEXT("GetTokenSupplies request failed")));
+    }
+    
+    return true;
+}
+
+void FIndexerGetTokenSuppliesTest::GetTests(TArray<FString>& OutBeautifiedNames, TArray<FString>& OutTestCommands) const
+{
+    OutBeautifiedNames.Add(TEXT("Indexer Get Token Supplies Test"));
+    OutTestCommands.Add(TEXT(""));
+}
+
+bool FIndexerGetTokenSuppliesTest::RunTest(const FString& Parameters)
+{
+    const int64 PolygonNetworkId = IndexerEndToEndTestsCommon::PolygonNetworkId;
+    const FString TestAddress = IndexerEndToEndTestsCommon::TestContractAddress_Skyweaver;
+    UIndexerRequestsTestData * IndexerRequestsTestData = UIndexerRequestsTestData::Make(1);
+
+    const TSuccessCallback<FSeqGetTokenSuppliesReturn> GenericSuccess = [this, IndexerRequestsTestData](const FSeqGetTokenSuppliesReturn& TokenSupplies)
+    {
+        TestNotNull(TEXT("TokenSupplies"), &TokenSupplies);
+        TestNotNull(TEXT("TokenSupplies.page"), &TokenSupplies.page);
+        TestEqual(TEXT("Contract type should be ERC1155"), TokenSupplies.contractType, ERC1155);
+        TestNotNull(TEXT("TokenSupplies.tokenIDs"), &TokenSupplies.tokenIDs);
+        TestTrue(TEXT("TokenSupplies.tokenIDs should not be empty"), TokenSupplies.tokenIDs.Num() > 0);
+
+        const FString Message = "GetTokenSupplies request succeeded";
+        AddInfo(FString::Printf(TEXT("%s. Remaining Requests: %d"), *Message, IndexerRequestsTestData->DecrementPendingRequests()));
+    };
+
+    const FFailureCallback GenericFailure = [this, IndexerRequestsTestData](const FSequenceError& Error)
+    {
+        const FString Message = "Request Failure";
+        AddError(FString::Printf(TEXT("%s: %s. Remaining requests: %d"), *Message, *Error.Message, IndexerRequestsTestData->DecrementPendingRequests()));
+        IndexerRequestsTestData->RequestFailed();
+    };
+
+    AddInfo(FString::Printf(TEXT("Starting GetTokenSupplies request")));
+
+    FSeqGetTokenSuppliesArgs Args;
+    Args.contractAddress = TestAddress;
+    IndexerRequestsTestData->GetIndexer()->GetTokenSupplies(PolygonNetworkId, Args, GenericSuccess, GenericFailure);
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FIsDoneGetTokenSupplies(IndexerRequestsTestData, this));
+    return true;
+}

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTransactionHistoryTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerGetTransactionHistoryTest.cpp
@@ -1,0 +1,69 @@
+// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
+
+#include "CoreMinimal.h"
+#include "Helpers/IndexerEndToEndTestsCommon.h"
+#include "Misc/AutomationTest.h"
+#include "Util/Async.h"
+#include "Helpers/IndexerRequestsTestData.h"
+
+IMPLEMENT_COMPLEX_AUTOMATION_TEST(FIndexerGetTransactionHistoryTest, "SequencePlugin.EndToEnd.IndexerTests.GetTransactionHistoryTest", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+/* Latent command used to poll off main thread to see if our requests are done */
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FIsDoneGetTransactionHistory, const UIndexerRequestsTestData *, IndexerRequestsTestData, FAutomationTestBase *, GetTransactionHistoryTest);
+
+bool FIsDoneGetTransactionHistory::Update()
+{
+    if (IndexerRequestsTestData->GetPendingRequests() == 0)
+    {
+        if (IndexerRequestsTestData->GetAllRequestsSuccessful())
+        {
+            GetTransactionHistoryTest->AddInfo(TEXT("GetTransactionHistory request completed successfully"));
+        }
+        else
+        {
+            GetTransactionHistoryTest->AddError(TEXT("GetTransactionHistory request failed"));
+        }
+        return true;
+    }
+    return false;
+}
+
+void FIndexerGetTransactionHistoryTest::GetTests(TArray<FString>& OutBeautifiedNames, TArray<FString>& OutTestCommands) const
+{
+    OutBeautifiedNames.Add(TEXT("Indexer Get Transaction History Test"));
+    OutTestCommands.Add(TEXT(""));
+}
+
+bool FIndexerGetTransactionHistoryTest::RunTest(const FString& Parameters)
+{
+    const int64 PolygonNetworkId = IndexerEndToEndTestsCommon::PolygonNetworkId;
+    const FString TestAddress = IndexerEndToEndTestsCommon::TestAddress;
+    UIndexerRequestsTestData* IndexerRequestsTestData = UIndexerRequestsTestData::Make(1);
+
+    const TSuccessCallback<FSeqGetTransactionHistoryReturn> GenericSuccess = [this, IndexerRequestsTestData](const FSeqGetTransactionHistoryReturn& History)
+    {
+        TestNotNull(TEXT("History"), &History);
+        TestNotNull(TEXT("History.page"), &History.page);
+        TestNotNull(TEXT("History.transactions"), &History.transactions);
+        TestTrue(TEXT("History.transactions should not be empty"), History.transactions.Num() > 0);
+
+        const FString Message = "GetTransactionHistory request succeeded";
+        AddInfo(FString::Printf(TEXT("%s. Remaining Requests: %d"), *Message, IndexerRequestsTestData->DecrementPendingRequests()));
+    };
+
+    const FFailureCallback GenericFailure = [this, IndexerRequestsTestData](const FSequenceError& Error)
+    {
+        const FString Message = "GetTransactionHistory Request Failure";
+        AddError(FString::Printf(TEXT("%s: %s. Remaining requests: %d"), *Message, *Error.Message, IndexerRequestsTestData->DecrementPendingRequests()));
+        IndexerRequestsTestData->RequestFailed();
+    };
+
+    AddInfo(TEXT("Starting GetTransactionHistory request"));
+
+    FSeqGetTransactionHistoryArgs Args;
+    Args.filter.accountAddress = TestAddress;
+    IndexerRequestsTestData->GetIndexer()->GetTransactionHistory(PolygonNetworkId, Args, GenericSuccess, GenericFailure);
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FIsDoneGetTransactionHistory(IndexerRequestsTestData, this));
+    return true;
+}


### PR DESCRIPTION
Added GetTokenSupplies and GetTransactionHistory tests for Indexer

Also, fixed a bug where, if not provided, the associated args would pass in a default Page object that the API isn't handling appropriately and giving empty responses