### PR TITLE
Feature/playfab validate input

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
@@ -822,7 +822,7 @@ void USequenceAuthenticator::FederatePlayFabNewAccount(const FString& UsernameIn
 
 		const FFailureCallback OnFederateFailure = [this](const FSequenceError& Error)
 		{
-			UE_LOG(LogTemp, Warning, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
+			UE_LOG(LogTemp, Error, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
 			this->CallFederateFailure(Error.Message);
 		};
 

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
@@ -682,17 +682,16 @@ FString USequenceAuthenticator::ValidateEmail(const FString& Email)
 		return "Email cannot be empty";
 	}
 
-	// Basic email validation
 	int32 AtIndex;
 
 	if (!Email.FindChar('@', AtIndex) || AtIndex == 0)
 	{
-		return TEXT("Email is invalid");
+		return TEXT("Email is invalid, given " + Email);
 	}
 
 	if (!Email.FindChar('.', AtIndex) || AtIndex == 0)
 	{
-		return TEXT("Email is invalid");
+		return TEXT("Email is invalid, given " + Email);
 	}
 
 	

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
@@ -822,7 +822,7 @@ void USequenceAuthenticator::FederatePlayFabNewAccount(const FString& UsernameIn
 
 		const FFailureCallback OnFederateFailure = [this](const FSequenceError& Error)
 		{
-			UE_LOG(LogTemp, Error, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
+			UE_LOG(LogTemp, Warning, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
 			this->CallFederateFailure(Error.Message);
 		};
 
@@ -842,7 +842,7 @@ void USequenceAuthenticator::FederatePlayFabNewAccount(const FString& UsernameIn
 
 	const FFailureCallback OnFailure = [this](const FSequenceError& Error)
 	{
-		UE_LOG(LogTemp, Error, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
+		UE_LOG(LogTemp, Warning, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
 		this->CallFederateFailure(Error.Message);
 	};
 
@@ -860,7 +860,7 @@ void USequenceAuthenticator::FederatePlayFabLogin(const FString& UsernameIn, con
 
 		const FFailureCallback OnFederateFailure = [this](const FSequenceError& Error)
 		{
-			UE_LOG(LogTemp, Error, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
+			UE_LOG(LogTemp, Warning, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
 			this->CallFederateFailure(Error.Message);
 		};
 		
@@ -880,7 +880,7 @@ void USequenceAuthenticator::FederatePlayFabLogin(const FString& UsernameIn, con
 
 	const FFailureCallback OnFailure = [this](const FSequenceError& Error)
 	{
-		UE_LOG(LogTemp, Error, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
+		UE_LOG(LogTemp, Warning, TEXT("Error Federating PlayFab Account: %s"), *Error.Message);
 		this->CallFederateFailure(Error.Message);
 	};
 

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
@@ -576,6 +576,17 @@ void USequenceAuthenticator::InitializeSequence(const FCredentials_BE& Credentia
 
 void USequenceAuthenticator::PlayFabLoginRPC(const FString& UsernameIn, const FString& PasswordIn, const TSuccessCallback<FString>& OnSuccess, const FFailureCallback& OnFailure)
 {
+	if (!USequenceAuthenticator::ValidateUsername(UsernameIn).IsEmpty())
+	{
+		OnFailure(FSequenceError(InvalidArgument, USequenceAuthenticator::ValidateUsername(UsernameIn)));
+		return;
+	}
+	if (!USequenceAuthenticator::ValidatePassword(PasswordIn).IsEmpty())
+	{
+		OnFailure(FSequenceError(InvalidArgument, USequenceAuthenticator::ValidatePassword(PasswordIn)));
+		return;
+	}
+	
 	const TFunction<void(FString)> OnSuccessResponse = [OnSuccess, OnFailure](const FString& Response)
 	{
 		if (const FPlayFabLoginUserResponse ParsedResponse = USequenceSupport::JSONStringToStruct<FPlayFabLoginUserResponse>(Response); ParsedResponse.IsValid())
@@ -597,6 +608,22 @@ void USequenceAuthenticator::PlayFabLoginRPC(const FString& UsernameIn, const FS
 
 void USequenceAuthenticator::PlayFabNewAccountLoginRPC(const FString& UsernameIn, const FString& EmailIn, const FString& PasswordIn, const TSuccessCallback<FString>& OnSuccess, const FFailureCallback& OnFailure)
 {
+	if (!USequenceAuthenticator::ValidateUsername(UsernameIn).IsEmpty())
+	{
+		OnFailure(FSequenceError(InvalidArgument, USequenceAuthenticator::ValidateUsername(UsernameIn)));
+		return;
+	}
+	if (!USequenceAuthenticator::ValidatePassword(PasswordIn).IsEmpty())
+	{
+		OnFailure(FSequenceError(InvalidArgument, USequenceAuthenticator::ValidatePassword(PasswordIn)));
+		return;
+	}
+	if (!USequenceAuthenticator::ValidateEmail(EmailIn).IsEmpty())
+	{
+		OnFailure(FSequenceError(InvalidArgument, USequenceAuthenticator::ValidateEmail(EmailIn)));
+		return;
+	}
+	
 	const TFunction<void(FString)> OnSuccessResponse = [OnSuccess, OnFailure](const FString& Response)
 	{
 		if (const FPlayFabRegisterUserResponse ParsedResponse = USequenceSupport::JSONStringToStruct<FPlayFabRegisterUserResponse>(Response); ParsedResponse.IsValid())
@@ -637,6 +664,52 @@ void USequenceAuthenticator::PlayFabRPC(const FString& Url, const FString& Conte
 	->WithVerb("POST")
 	->WithContentAsString(Content)
 	->ProcessAndThen(OnSuccess, OnFailure);
+}
+
+FString USequenceAuthenticator::ValidateUsername(const FString& Username)
+{
+	if (Username.IsEmpty())
+	{
+		return "Username cannot be empty";
+	}
+	return "";
+}
+
+FString USequenceAuthenticator::ValidateEmail(const FString& Email)
+{
+	if (Email.IsEmpty())
+	{
+		return "Email cannot be empty";
+	}
+
+	// Basic email validation
+	int32 AtIndex;
+
+	if (!Email.FindChar('@', AtIndex) || AtIndex == 0)
+	{
+		return TEXT("Email is invalid");
+	}
+
+	if (!Email.FindChar('.', AtIndex) || AtIndex == 0)
+	{
+		return TEXT("Email is invalid");
+	}
+
+	
+	return "";
+}
+
+FString USequenceAuthenticator::ValidatePassword(const FString& Password)
+{
+	if (Password.IsEmpty())
+	{
+		return "Password cannot be empty";
+	}
+	if (Password.Len() < 8)
+	{
+		return "Password must be at least 8 characters long";
+	}
+	return "";
 }
 
 void USequenceAuthenticator::EmailLoginCode(const FString& CodeIn)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Errors.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Errors.h
@@ -14,6 +14,7 @@ enum EErrorType
 	TestFail,
 	TimeMismatch,
 	FailedToParseIntentTime,
+	InvalidArgument,
 };
 
 class SEQUENCEPLUGIN_API FSequenceError

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/SequenceAuthenticator.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/SequenceAuthenticator.h
@@ -271,6 +271,7 @@ public:
 	 */
 	void PlayFabAuthenticateWithSessionTicket(const FString& SessionTicket);
 
+	static FString ValidatePassword(const FString& Password);
 	/**
 	 * Used to complete Email based authentication, whether it be for normal Authentication OR Federation
 	 * @param CodeIn Received Code from email
@@ -385,6 +386,8 @@ private:
 	static FString GeneratePlayFabRegisterUrl();
 	
 	static void PlayFabRPC(const FString& Url, const FString& Content, const TSuccessCallback<FString>& OnSuccess, const FFailureCallback& OnFailure);
-	
+	static FString ValidateUsername(const FString& Username);
+	static FString ValidateEmail(const FString& Email);
+
 	//PlayFab RPC//
 };

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.cpp
@@ -1,0 +1,205 @@
+#include "PlayfabInputValidationTest.h"
+#include "Engine/World.h"
+#include "Misc/OutputDeviceNull.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+
+IMPLEMENT_COMPLEX_AUTOMATION_TEST(FPlayFabInputValidationTests, "SequencePlugin.EndToEnd.SessionManagement.PlayFabInputValidation", 
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter | EAutomationTestFlags::ClientContext)
+
+void FPlayFabInputValidationTests::GetTests(TArray<FString>& OutBeautifiedNames, TArray<FString>& OutTestCommands) const
+{
+    OutBeautifiedNames.Add(TEXT("Login Input Validation"));
+    OutTestCommands.Add(TEXT("login"));
+
+    OutBeautifiedNames.Add(TEXT("Federation Input Validation"));
+    OutTestCommands.Add(TEXT("federation"));
+}
+
+bool FPlayFabInputValidationTests::RunTest(const FString& Parameters)
+{
+    AddInfo(TEXT("Starting PlayFab Input Validation Test"));
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FStartPIECommand(true));
+    ADD_LATENT_AUTOMATION_COMMAND(FEngineWaitLatentCommand(1.0f));
+    
+    ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, Parameters]()
+    {
+        UPlayFabInputValidationTestHelper* TestHelper = NewObject<UPlayFabInputValidationTestHelper>();
+        TestHelper->ParentTest = this;
+        
+        if (Parameters == TEXT("login"))
+        {
+            TestHelper->SetIsLoginTest(true);
+            TestHelper->RunLoginValidationTests();
+        }
+        else
+        {
+            TestHelper->SetIsLoginTest(false);
+            TestHelper->RunFederationValidationTests();
+        }
+
+        ADD_LATENT_AUTOMATION_COMMAND(FWaitForValidationTestComplete(TestHelper));
+        return true;
+    }));
+
+    return true;
+}
+
+void UPlayFabInputValidationTestHelper::RunLoginValidationTests()
+{
+    bTestComplete = false;
+    
+    if (!Authenticator)
+    {
+        Authenticator = NewObject<USequenceAuthenticator>();
+        Authenticator->AuthSuccess.AddDynamic(this, &UPlayFabInputValidationTestHelper::OnAuthSuccess);
+        Authenticator->AuthFailure.AddDynamic(this, &UPlayFabInputValidationTestHelper::OnAuthFailure);
+    }
+
+    if (LastError.IsEmpty())
+    {
+        ParentTest->AddInfo(TEXT("Testing empty username"));
+        Authenticator->PlayFabLogin(TEXT(""), TEXT("validpassword123"), false);
+    }
+    else if (LastError.Contains(TEXT("Username cannot be empty")))
+    {
+        ParentTest->AddInfo(TEXT("Testing empty password"));
+        Authenticator->PlayFabLogin(TEXT("validusername"), TEXT(""), false);
+    }
+    else if (LastError.Contains(TEXT("Password cannot be empty")))
+    {
+        ParentTest->AddInfo(TEXT("Testing short password"));
+        Authenticator->PlayFabLogin(TEXT("validusername"), TEXT("short"), false);
+    }
+    else if (LastError.Contains(TEXT("Password must be at least 8 characters")))
+    {
+        bTestComplete = true;
+        bTestPassed = true;
+        bAllTestsComplete = true;
+        ParentTest->AddInfo(TEXT("All login validation tests completed successfully"));
+    }
+    else
+    {
+        bTestComplete = true;
+        bTestPassed = false;
+        bAllTestsComplete = true;
+        ParentTest->AddInfo(TEXT("Received unexpected error message: " + LastError));
+    }
+}
+
+void UPlayFabInputValidationTestHelper::RunFederationValidationTests()
+{
+    bTestComplete = false;
+    
+    if (!Authenticator)
+    {
+        Authenticator = NewObject<USequenceAuthenticator>();
+        Authenticator->FederateSuccess.AddDynamic(this, &UPlayFabInputValidationTestHelper::OnFederateSuccess);
+        Authenticator->FederateFailure.AddDynamic(this, &UPlayFabInputValidationTestHelper::OnFederateFailure);
+    }
+
+    if (LastError.IsEmpty())
+    {
+        ParentTest->AddInfo(TEXT("Testing empty username for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT(""), TEXT("valid@email.com"), TEXT("validpassword123"));
+    }
+    else if (LastError.Contains(TEXT("Username cannot be empty")))
+    {
+        ParentTest->AddInfo(TEXT("Testing empty email for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT("validusername"), TEXT(""), TEXT("validpassword123"));
+    }
+    else if (LastError.Contains(TEXT("Email cannot be empty")))
+    {
+        ParentTest->AddInfo(TEXT("Testing invalid email format (no @) for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT("validusername"), TEXT("invalidemail"), TEXT("validpassword123"));
+    }
+    else if (LastError.Contains(TEXT("Email is invalid, given invalidemail")))
+    {
+        ParentTest->AddInfo(TEXT("Testing invalid email format (no domain) for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT("validusername"), TEXT("invalid@"), TEXT("validpassword123"));
+    }
+    else if (LastError.Contains(TEXT("Email is invalid, given invalid@")))
+    {
+        ParentTest->AddInfo(TEXT("Testing empty password for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT("validusername"), TEXT("valid@email.com"), TEXT(""));
+    }
+    else if (LastError.Contains(TEXT("Password cannot be empty")))
+    {
+        ParentTest->AddInfo(TEXT("Testing short password for federation"));
+        Authenticator->FederatePlayFabNewAccount(TEXT("validusername"), TEXT("valid@email.com"), TEXT("short"));
+    }
+    else if (LastError.Contains(TEXT("Password must be at least 8 characters")))
+    {
+        bTestComplete = true;
+        bTestPassed = true;
+        bAllTestsComplete = true;
+        ParentTest->AddInfo(TEXT("All federation validation tests completed successfully"));
+    }
+    else
+    {
+        bTestComplete = true;
+        bTestPassed = false;
+        bAllTestsComplete = true;
+        ParentTest->AddInfo(TEXT("Received unexpected error message: " + LastError));
+    }
+}
+
+void UPlayFabInputValidationTestHelper::OnAuthSuccess()
+{
+    bTestComplete = true;
+    bTestPassed = false;
+    LastError = TEXT("Auth succeeded when it should have failed validation");
+    ParentTest->AddError(LastError);
+}
+
+void UPlayFabInputValidationTestHelper::OnAuthFailure(const FString& Error)
+{
+    bTestComplete = true;
+    bTestPassed = true;
+    LastError = Error;
+    ParentTest->AddInfo(FString::Printf(TEXT("Auth failed as expected with error: %s"), *Error));
+}
+
+void UPlayFabInputValidationTestHelper::OnFederateSuccess()
+{
+    bTestComplete = true;
+    bTestPassed = false;
+    LastError = TEXT("Federation succeeded when it should have failed validation");
+    ParentTest->AddError(LastError);
+}
+
+void UPlayFabInputValidationTestHelper::OnFederateFailure(const FString& Error)
+{
+    bTestComplete = true;
+    bTestPassed = true;
+    LastError = Error;
+    ParentTest->AddInfo(FString::Printf(TEXT("Federation failed as expected with error: %s"), *Error));
+}
+
+bool FWaitForValidationTestComplete::Update()
+{
+    if (!TestHelper->IsTestComplete())
+    {
+        return false;
+    }
+
+    if (!TestHelper->GetTestPassed() || TestHelper->AreAllTestsComplete())
+    {
+        if (TestHelper->GetTestPassed())
+        {
+            TestHelper->ParentTest->TestTrue(TEXT("All validation tests completed successfully"), true);
+        }
+        return true;
+    }
+
+    if (TestHelper->IsLoginTest())
+    {
+        TestHelper->RunLoginValidationTests();
+    }
+    else
+    {
+        TestHelper->RunFederationValidationTests();
+    }
+    return false;
+}

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.h
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.h
@@ -29,8 +29,17 @@ public:
 	bool GetTestPassed() const { return bTestPassed; }
 	bool AreAllTestsComplete() const { return bAllTestsComplete; }
 	FString GetLastError() const { return LastError; }
-	void SetIsLoginTest(bool bIsLogin) { bIsLoginTest = bIsLogin; }
+	void SetIsLoginTest(bool bIsLogin) { bIsLoginTest = true; }
 	bool IsLoginTest() const { return bIsLoginTest; }
+	void SetIsNewAccountTest(bool bIsNewAccount) { bIsNewAccountTest = true; }
+	bool IsNewAccountTest() const { return bIsNewAccountTest; }
+	void SetIsFederationTest(bool bIsFederation) { bIsFederationTest = true; }
+	bool IsFederationTest() const { return bIsFederationTest; }
+	void SetIsFederationLoginTest(bool bIsFederationLogin) { bIsFederationLoginTest = true; }
+	bool IsFederationLoginTest() const { return bIsFederationLoginTest; }
+
+	void RunNewAccountValidationTests();
+	void RunFederationLoginValidationTests();
 
 	class FAutomationTestBase* ParentTest;
 
@@ -41,6 +50,9 @@ private:
 	FString LastError;
 	USequenceAuthenticator* Authenticator = nullptr;
 	bool bIsLoginTest = false;
+	bool bIsNewAccountTest = false;
+	bool bIsFederationTest = false;
+	bool bIsFederationLoginTest = false;
 };
 
 DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FWaitForValidationTestComplete, UPlayFabInputValidationTestHelper*, TestHelper);

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.h
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/SessionManagementEndToEndTests/PlayfabInputValidationTest.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "SequencePlugin/Public/SequenceAuthenticator.h"
+#include "PlayfabInputValidationTest.generated.h"
+
+UCLASS()
+class UPlayFabInputValidationTestHelper : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION()
+	void OnAuthSuccess();
+
+	UFUNCTION()
+	void OnAuthFailure(const FString& Error);
+
+	UFUNCTION()
+	void OnFederateSuccess();
+
+	UFUNCTION()
+	void OnFederateFailure(const FString& Error);
+
+	void RunLoginValidationTests();
+	void RunFederationValidationTests();
+	bool IsTestComplete() const { return bTestComplete; }
+	bool GetTestPassed() const { return bTestPassed; }
+	bool AreAllTestsComplete() const { return bAllTestsComplete; }
+	FString GetLastError() const { return LastError; }
+	void SetIsLoginTest(bool bIsLogin) { bIsLoginTest = bIsLogin; }
+	bool IsLoginTest() const { return bIsLoginTest; }
+
+	class FAutomationTestBase* ParentTest;
+
+private:
+	bool bTestComplete = false;
+	bool bTestPassed = false;
+	bool bAllTestsComplete = false;
+	FString LastError;
+	USequenceAuthenticator* Authenticator = nullptr;
+	bool bIsLoginTest = false;
+};
+
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FWaitForValidationTestComplete, UPlayFabInputValidationTestHelper*, TestHelper);


### PR DESCRIPTION
Added some simple validation for the username, email, and password we send to PlayFab for authentication. Failure to do so can cause crashes, specifically if empty values are provided

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
