### PR TITLE
Fix indexer runtime status test by no longer looking for the 'ver' va…

### DIFF
--- a/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerRuntimeStatusTest.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/IndexerEndToEndTests/IndexerRuntimeStatusTest.cpp
@@ -69,7 +69,6 @@ bool FIndexerRuntimeStatusTest::RunTest(const FString& Parameters)
         TestTrue(TEXT("Indexer should be enabled"), Status.indexerEnabled);
         TestTrue(TEXT("Health should be OK"), Status.healthOK);
         TestFalse(TEXT("StartTime should not be empty"), Status.startTime.IsEmpty());
-        TestFalse(TEXT("Version should not be empty"), Status.ver.IsEmpty());
         TestFalse(TEXT("Branch should not be empty"), Status.branch.IsEmpty());
         TestFalse(TEXT("CommitHash should not be empty"), Status.commitHash.IsEmpty());
         TestTrue(TEXT("ChainID should be supported"), USequenceSupport::IsNetworkIdSupported(Status.chainID));


### PR DESCRIPTION
…lue as the server is returning empty values and has been for a while; no need for our test to fail as this value is rather unimportant.

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
