### PR TITLE
Fix to prevent crashing when logging in with corrupted save file on Mac

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/AppleBridge.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/AppleBridge.cpp
@@ -32,8 +32,16 @@ FString UAppleBridge::AppleDecrypt(const FString& StringIn)
 #if PLATFORM_IOS || PLATFORM_MAC
 	NSString * _ToDecrypt = StringIn.GetNSString();
 	NativeAppleEncryptor * Encryptor = [[NativeAppleEncryptor alloc] init];
-	char * CharResult = [Encryptor Decrypt:_ToDecrypt];
-	Result = FString(UTF8_TO_TCHAR(CharResult));
+	
+	@try {
+		char * CharResult = [Encryptor Decrypt:_ToDecrypt];
+		Result = FString(UTF8_TO_TCHAR(CharResult));
+	}
+	@catch (NSException *exception) {
+		// Handle the exception and log the error
+		NSLog(@"Caught exception: %@ - Reason: %@", exception.name, exception.reason);
+	}
+
 #endif
 	return Result;
 }

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/SequenceAuthenticator.cpp
@@ -250,6 +250,7 @@ bool USequenceAuthenticator::GetStoredCredentials(FCredentials_BE* Credentials) 
 		if (const UStorableCredentials* LoadedCredentials = Cast<UStorableCredentials>(SaveGame))
 		{
 			FString CTR_Json = "";
+
 			if (Encryptor)
 			{//Use set encryptor
 				CTR_Json = Encryptor->Decrypt(LoadedCredentials->EK);
@@ -261,6 +262,13 @@ bool USequenceAuthenticator::GetStoredCredentials(FCredentials_BE* Credentials) 
 
 			ret = USequenceSupport::JSONStringToStruct<FCredentials_BE>(CTR_Json, Credentials);
 			ret &= Credentials->RegisteredValid();
+
+			if (ret == false)
+			{
+				// Assumed that there is an issue with the save file, therefore we'll just delete the save file
+				UE_LOG(LogTemp, Error, TEXT("[System Failure: Unable to read save file or file is corrupted]"));
+				UGameplayStatics::DeleteGameInSlot(this->SaveSlot, this->UserIndex);
+			}
 		}
 	}
 	return ret;


### PR DESCRIPTION
Added a Try Catch to AppleBridge to ensure the the editor doesn't crash if corrupted save data is passed along to be decrypted.
If save file is found but unable to be read, it is now just removed.

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
