### PR TITLE
Engine should no longer crash on Mac due to a corrupted save file

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/AppleBridge.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/AppleBridge.cpp
@@ -32,16 +32,8 @@ FString UAppleBridge::AppleDecrypt(const FString& StringIn)
 #if PLATFORM_IOS || PLATFORM_MAC
 	NSString * _ToDecrypt = StringIn.GetNSString();
 	NativeAppleEncryptor * Encryptor = [[NativeAppleEncryptor alloc] init];
-	
-	@try {
-		char * CharResult = [Encryptor Decrypt:_ToDecrypt];
-		Result = FString(UTF8_TO_TCHAR(CharResult));
-	}
-	@catch (NSException *exception) {
-		// Handle the exception and log the error
-		NSLog(@"Caught exception: %@ - Reason: %@", exception.name, exception.reason);
-	}
-
+	char * CharResult = [Encryptor Decrypt:_ToDecrypt];
+	Result = FString(UTF8_TO_TCHAR(CharResult));
 #endif
 	return Result;
 }

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/IOS/objective_c/NativeAppleEncryptor.mm
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Native/IOS/objective_c/NativeAppleEncryptor.mm
@@ -1,4 +1,4 @@
-﻿// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
+// Copyright 2024 Horizon Blockchain Games Inc. All rights reserved.
 
 #import "NativeAppleEncryptor.h"
 #import <Foundation/Foundation.h>
@@ -105,14 +105,24 @@ static SecKeyRef PublicKeyRef = NULL;
 }
 
 - (char *)Decrypt:(NSString *)str
-{    
+{
+    if (str == nil || [str length] == 0) {
+        NSString *FailureString = @"Invalid input string";
+        return [self ConvertNSStringToChars:FailureString];
+    }
+
     if ([self LoadKeys])
     {
         NSData *DecodedData = [[NSData alloc] initWithBase64EncodedString:str options:0];
+        if (DecodedData == nil) {
+            NSString *FailureString = @"Failed to decode base64 input";
+            return [self ConvertNSStringToChars:FailureString];
+        }
+
         CFDataRef plainText = (__bridge CFDataRef)DecodedData;
         CFErrorRef error = NULL;
             
-        CFDataRef cfDecryptedData = SecKeyCreateDecryptedData(PrivateKeyRef,algorithm,plainText,&error);
+        CFDataRef cfDecryptedData = SecKeyCreateDecryptedData(PrivateKeyRef, algorithm, plainText, &error);
         
         if (cfDecryptedData)
         {
@@ -125,7 +135,8 @@ static SecKeyRef PublicKeyRef = NULL;
         else
         {
             NSError *err = CFBridgingRelease(error);
-            char * ErrorChars = [self ConvertNSStringToChars:err.localizedDescription];
+            NSString *errorString = err ? err.localizedDescription : @"Unknown decryption error";
+            char * ErrorChars = [self ConvertNSStringToChars:errorString];
             [self Clean];
             return ErrorChars;
         }
@@ -133,9 +144,7 @@ static SecKeyRef PublicKeyRef = NULL;
     else
     {
         NSString * FailureString = @"Failed to load keys";
-        char * ErrorChars = [self ConvertNSStringToChars:FailureString];
-        [self Clean];
-        return ErrorChars;
+        return [self ConvertNSStringToChars:FailureString];
     }
 }
 


### PR DESCRIPTION
Removed a Try Catch statement from Apple Bridge Decrypt that wouldn't have been allowed.  Updated NativeApplyEncryptor.mm to better handle situations of null or empty NSString values sent into Decrypt

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
