### PR TITLE
Add a check to confirm that a session is valid with the Sequence API.…

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Sequence/SequenceAPI.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Sequence/SequenceAPI.h
@@ -26,6 +26,15 @@ class UIndexer;
 class UProvider;
 class USequenceRPCManager;
 
+UENUM(Blueprintable)
+enum class ESessionState : uint8
+{
+	Unchecked UMETA(DisplayName = "Unchecked"),
+	Valid UMETA(DisplayName = "Valid"),
+	Invalid UMETA(DisplayName = "Invalid"),
+	Checking UMETA(DisplayName = "Checking"),
+};
+
 UCLASS()
 class SEQUENCEPLUGIN_API USequenceWallet : public UGameInstanceSubsystem
 {
@@ -46,6 +55,9 @@ private:
 
 	UPROPERTY()
 	FCredentials_BE Credentials;
+
+	UPROPERTY()
+	ESessionState SessionState = ESessionState::Unchecked;
 
 public:
 	USequenceWallet();
@@ -120,6 +132,12 @@ public:
 	 */
 	static float GetUserReadableAmount(const int64 AmountIn, const int64 DecimalsIn);
 
+	/**
+	 * Check if the wallet and stored credentials are registered to a valid session with the Sequence API
+	 * @return true if the wallet is signed in to Sequence API
+	 */
+	bool IsValidSession();
+	
 	/**
 	 * Returns the wallet address of the currently signed in user
 	 * @return wallet address of the currently signed in user


### PR DESCRIPTION
… Previously, we simply assumed that if credentials were stored and they weren't expired (i.e. the id token wasn't expired) then the session was valid. However, this isn't the case, it is possible that the session with the WaaS API has expired but the credentials are still valid - this leads to an annoying UX where the code assumes the user is logged in and doesn't discover that the session is not valid until it is attempting to do something with the wallet (e.g. send a transaction); the integrator would need to catch this error and then have the user re-authenticate, disrupting the end UX. This commit aims to reduce (though unfortunately not eliminate altogether) the possibility of this happening by performing a check against the API to see if it passes (simply by sending an intent), confirming the session is valid. Since getting the walid (and checking if session is valid) is a non-async call and we don't want to make it async as this would be a significant breaking change for integrators, we compromise by performing the check in the background when the integrator first grabs a reference to the wallet; once the check is completed, all subsequent attempts to access the wallet via the Get method will fail (assuming the session is determined to be invalid, otherwise the Get method will still work).

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
