### PR TITLE
Fix github workflow such that it better accomodates PRs from forks th…

### DIFF
--- a/.github/workflows/validate-pr-template.yml
+++ b/.github/workflows/validate-pr-template.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - name: Check PR Template Completion
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Fetch the pull request body
-          PR_BODY=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
-            | jq -r '.body')
+          if [ -z "$PR_BODY" ]; then
+            echo "Error: PR body is empty or unavailable."
+            exit 1
+          fi
 
-          # Check if one of the required checkboxes in the 'Docs Checklist' is marked
           if ! echo "$PR_BODY" | grep -Eq '\[x\] I have created a separate PR on the sequence docs repository for documentation updates|\[x\] No documentation update is needed for this change'; then
             echo "Error: The 'Docs Checklist' section in the PR template has not been completed properly."
             echo "Please ensure you have checked one of the options in the 'Docs Checklist' section."


### PR DESCRIPTION
…at won't have access to the project access tokens. Also, store the pr body in an .env so that it can't potentially be used for an injection attack, see https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions\#example-of-a-script-injection-attack

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
