### PR TITLE
Fixed the constructors for our token wrappers - providing a static Cr…

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC1155.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC1155.cpp
@@ -5,10 +5,17 @@ UERC1155::UERC1155()
 {
 }
 
-UERC1155::UERC1155(FString ContractAddress, FString Data)
+UERC1155* UERC1155::Create(const FString& ContractAddress, const FString& Data)
 {
-	this->ContractAddress = ContractAddress;
-	this->Data = Data;
+	UERC1155* ERC1155 = NewObject<UERC1155>();
+	ERC1155->Init(ContractAddress, Data);
+	return ERC1155;
+}
+
+void UERC1155::Init(const FString& InContractAddress, const FString& InData)
+{
+	this->ContractAddress = InContractAddress;
+	this->Data = InData;
 }
 
 FRawTransaction UERC1155::MakeGrantRoleTransaction(const FString& role, const FString& ToAddress)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC1155SaleContract.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC1155SaleContract.cpp
@@ -6,12 +6,19 @@ UERC1155SaleContract::UERC1155SaleContract()
 {
 }
 
-UERC1155SaleContract::UERC1155SaleContract(FString ContractAddress, FString PaymentToken, int32 MaxTotal, FString Data)
+UERC1155SaleContract* UERC1155SaleContract::Create(const FString& ContractAddress, const FString& PaymentToken, int32 MaxTotal, const FString& Data)
 {
-	this->ContractAddress = ContractAddress;
-	this->PaymentToken = PaymentToken;
-	this->MaxTotal = MaxTotal;
-	this->Data = Data;
+	UERC1155SaleContract* Contract = NewObject<UERC1155SaleContract>();
+	Contract->Init(ContractAddress, PaymentToken, MaxTotal, Data);
+	return Contract;
+}
+
+void UERC1155SaleContract::Init(const FString& InContractAddress, const FString& InPaymentToken, int32 InMaxTotal, const FString& InData)
+{
+	this->ContractAddress = InContractAddress;
+	this->PaymentToken = InPaymentToken;
+	this->MaxTotal = InMaxTotal;
+	this->Data = InData;
 }
 
 FRawTransaction UERC1155SaleContract::MakePurchaseTransaction(const FString& ToAddress, const TArray<int32>& TokenIds, const TArray<int32>& Amounts, const TArray<FString>& Proof)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC20.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC20.cpp
@@ -5,9 +5,16 @@ UERC20::UERC20()
 {
 }
 
-UERC20::UERC20(FString ContractAddress)
+UERC20* UERC20::Create(const FString& ContractAddress)
 {
-	this->ContractAddress = ContractAddress;
+	UERC20* ERC20 = NewObject<UERC20>();
+	ERC20->Init(ContractAddress);
+	return ERC20;
+}
+
+void UERC20::Init(const FString& InContractAddress)
+{
+	this->ContractAddress = InContractAddress;
 }
 
 FRawTransaction UERC20::MakeGrantRoleTransaction(const FString& role,const FString& ToAddress)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC721.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC721.cpp
@@ -5,9 +5,16 @@ UERC721::UERC721()
 {
 }
 
-UERC721::UERC721(FString ContractAddress)
+UERC721* UERC721::Create(const FString& ContractAddress)
 {
-	this->ContractAddress = ContractAddress;
+	UERC721* ERC721 = NewObject<UERC721>();
+	ERC721->Init(ContractAddress);
+	return ERC721;
+}
+
+void UERC721::Init(const FString& InContractAddress)
+{
+	this->ContractAddress = InContractAddress;
 }
 
 FRawTransaction UERC721::MakeGrantRoleTransaction(const FString& role, const FString& ToAddress)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC721SaleContract.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Types/ERC721SaleContract.cpp
@@ -6,12 +6,19 @@ UERC721SaleContract::UERC721SaleContract()
 {
 }
 
-UERC721SaleContract::UERC721SaleContract(FString ContractAddress, FString PaymentToken, int32 MaxTotal, FString Data)
+UERC721SaleContract* UERC721SaleContract::Create(const FString& ContractAddress, const FString& PaymentToken, int32 MaxTotal, const FString& Data)
 {
-    this->ContractAddress = ContractAddress;
-    this->PaymentToken = PaymentToken;
-    this->MaxTotal = MaxTotal;
-    this->Data = Data;
+    UERC721SaleContract* Contract = NewObject<UERC721SaleContract>();
+    Contract->Init(ContractAddress, PaymentToken, MaxTotal, Data);
+    return Contract;
+}
+
+void UERC721SaleContract::Init(const FString& InContractAddress, const FString& InPaymentToken, int32 InMaxTotal, const FString& InData)
+{
+    this->ContractAddress = InContractAddress;
+    this->PaymentToken = InPaymentToken;
+    this->MaxTotal = InMaxTotal;
+    this->Data = InData;
 }
 
 FRawTransaction UERC721SaleContract::MakePurchaseTransaction(const FString& ToAddress, const int32& Amount, const TArray<FString>& Proof)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC1155.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC1155.h
@@ -11,10 +11,10 @@ class SEQUENCEPLUGIN_API UERC1155 : public UObject
 	GENERATED_BODY()
 
 public: 
-
 	UERC1155();
 
-	UERC1155(FString ContractAddress, FString Data);
+	UFUNCTION(BlueprintCallable, Category = "ERC1155")
+	static UERC1155* Create(const FString& ContractAddress, const FString& Data);
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = true), Category = "ERC1155")
 	FString ContractAddress;
@@ -39,6 +39,8 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ERC1155")
 	FRawTransaction MakeBatchBurnTransaction(const TArray<int32>& TokenIds, const TArray<int32>& Amounts);
-	
+
+private:
+	void Init(const FString& InContractAddress, const FString& InData);
 };
 

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC1155SaleContract.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC1155SaleContract.h
@@ -14,7 +14,8 @@ class SEQUENCEPLUGIN_API UERC1155SaleContract : public UObject
 public:
     UERC1155SaleContract();
 
-    UERC1155SaleContract(FString ContractAddress, FString PaymentToken, int32 MaxTotal, FString Data);
+    UFUNCTION(BlueprintCallable, Category = "ERC1155 Sale")
+    static UERC1155SaleContract* Create(const FString& ContractAddress, const FString& PaymentToken, int32 MaxTotal, const FString& Data);
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = true), Category = "ERC1155 Sale")
     FString ContractAddress;
@@ -31,10 +32,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "ERC1155 Sale")
     FRawTransaction MakePurchaseTransaction(const FString& ToAddress, const TArray<int32>& TokenIds, const TArray<int32>& Amounts, const TArray<FString>& Proof);
 
-
     FContractCall GetPaymentToken();
 
     FContractCall GetGlobalSaleDetails();
 
-
+private:
+    void Init(const FString& InContractAddress, const FString& InPaymentToken, int32 InMaxTotal, const FString& InData);
 };

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC20.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC20.h
@@ -11,11 +11,10 @@ class SEQUENCEPLUGIN_API UERC20 : public UObject
 	GENERATED_BODY()
 
 public:
-
 	UERC20();
 
-
-	UERC20(FString ContractAddress);
+	UFUNCTION(BlueprintCallable, Category = "ERC20")
+	static UERC20* Create(const FString& ContractAddress);
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = true), Category = "ERC20")
 	FString ContractAddress;
@@ -31,5 +30,8 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ERC20")
 	FRawTransaction MakeBurnTransaction(const int32 Amount);
+
+private:
+	void Init(const FString& InContractAddress);
 };
  

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC721.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC721.h
@@ -10,10 +10,10 @@ class SEQUENCEPLUGIN_API UERC721 : public UObject
 	GENERATED_BODY()
 
 public:
-
 	UERC721();
-
-	UERC721(FString ContractAddress);
+	
+	UFUNCTION(BlueprintCallable, Category = "ERC721")
+	static UERC721* Create(const FString& ContractAddress);
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = true), Category = "ERC721")
 	FString ContractAddress;
@@ -32,5 +32,8 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ERC721")
 	FRawTransaction MakeBatchBurnTransaction(const TArray<int32>& TokenIds);
+
+private:
+	void Init(const FString& InContractAddress);
 };
 

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC721SaleContract.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Types/ERC721SaleContract.h
@@ -12,10 +12,10 @@ class SEQUENCEPLUGIN_API UERC721SaleContract : public UObject
     GENERATED_BODY()
 
 public:
-
     UERC721SaleContract();
 
-    UERC721SaleContract(FString ContractAddress, FString PaymentToken, int32 MaxTotal, FString Data);
+    UFUNCTION(BlueprintCallable, Category = "ERC721 Sale")
+    static UERC721SaleContract* Create(const FString& ContractAddress, const FString& PaymentToken, int32 MaxTotal, const FString& Data);
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = true), Category = "ERC721 Sale")
     FString ContractAddress;
@@ -34,4 +34,6 @@ public:
 
     FContractCall GetSaleDetails();
 
+private:
+    void Init(const FString& InContractAddress, const FString& InPaymentToken, int32 InMaxTotal, const FString& InData);
 };

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC1155SaleTests.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC1155SaleTests.cpp
@@ -1,0 +1,22 @@
+#include "CoreMinimal.h"
+#include "Types/ERC1155SaleContract.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTokenWrapper_ERC1155Sale_Create, "SequencePlugin.UnitTests.TokenWrapper.ERC1155Sale_Create", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FTokenWrapper_ERC1155Sale_Create::RunTest(const FString& Parameters)
+{
+    const FString TestAddress = "0x1234567890123456789012345678901234567890";
+    const FString TestPaymentToken = "0x0987654321098765432109876543210987654321";
+    const int32 TestMaxTotal = 1000;
+    const FString TestData = "test_data";
+    
+    UERC1155SaleContract* Contract = UERC1155SaleContract::Create(TestAddress, TestPaymentToken, TestMaxTotal, TestData);
+    
+    TestNotNull("Contract should not be null", Contract);
+    TestEqual("Contract address should match", Contract->ContractAddress, TestAddress);
+    TestEqual("Payment token should match", Contract->PaymentToken, TestPaymentToken);
+    TestEqual("Max total should match", Contract->MaxTotal, TestMaxTotal);
+    TestEqual("Data should match", Contract->Data, TestData);
+    
+    return true;
+} 

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC1155Tests.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC1155Tests.cpp
@@ -1,0 +1,17 @@
+#include "CoreMinimal.h"
+#include "Types/ERC1155.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTokenWrapper_ERC1155_Create, "SequencePlugin.UnitTests.TokenWrapper.ERC1155_Create", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FTokenWrapper_ERC1155_Create::RunTest(const FString& Parameters)
+{
+    const FString TestAddress = "0x1234567890123456789012345678901234567890";
+    const FString TestData = "test_data";
+    UERC1155* Token = UERC1155::Create(TestAddress, TestData);
+    
+    TestNotNull("Token should not be null", Token);
+    TestEqual("Contract address should match", Token->ContractAddress, TestAddress);
+    TestEqual("Data should match", Token->Data, TestData);
+    
+    return true;
+} 

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC20Tests.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC20Tests.cpp
@@ -1,0 +1,15 @@
+#include "CoreMinimal.h"
+#include "Types/ERC20.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTokenWrapper_ERC20_Create, "SequencePlugin.UnitTests.TokenWrapper.ERC20_Create", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FTokenWrapper_ERC20_Create::RunTest(const FString& Parameters)
+{
+    const FString TestAddress = "0x1234567890123456789012345678901234567890";
+    UERC20* Token = UERC20::Create(TestAddress);
+    
+    TestNotNull("Token should not be null", Token);
+    TestEqual("Contract address should match", Token->ContractAddress, TestAddress);
+    
+    return true;
+} 

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC721SaleTests.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC721SaleTests.cpp
@@ -1,0 +1,22 @@
+#include "CoreMinimal.h"
+#include "Types/ERC721SaleContract.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTokenWrapper_ERC721Sale_Create, "SequencePlugin.UnitTests.TokenWrapper.ERC721Sale_Create", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FTokenWrapper_ERC721Sale_Create::RunTest(const FString& Parameters)
+{
+    const FString TestAddress = "0x1234567890123456789012345678901234567890";
+    const FString TestPaymentToken = "0x0987654321098765432109876543210987654321";
+    const int32 TestMaxTotal = 1000;
+    const FString TestData = "test_data";
+    
+    UERC721SaleContract* Contract = UERC721SaleContract::Create(TestAddress, TestPaymentToken, TestMaxTotal, TestData);
+    
+    TestNotNull("Contract should not be null", Contract);
+    TestEqual("Contract address should match", Contract->ContractAddress, TestAddress);
+    TestEqual("Payment token should match", Contract->PaymentToken, TestPaymentToken);
+    TestEqual("Max total should match", Contract->MaxTotal, TestMaxTotal);
+    TestEqual("Data should match", Contract->Data, TestData);
+    
+    return true;
+} 

--- a/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC721Tests.cpp
+++ b/Plugins/SequenceTests/Source/SequenceTests/Private/TokenWrapperTests/ERC721Tests.cpp
@@ -1,0 +1,15 @@
+#include "CoreMinimal.h"
+#include "Types/ERC721.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTokenWrapper_ERC721_Create, "SequencePlugin.UnitTests.TokenWrapper.ERC721_Create", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+bool FTokenWrapper_ERC721_Create::RunTest(const FString& Parameters)
+{
+    const FString TestAddress = "0x1234567890123456789012345678901234567890";
+    UERC721* Token = UERC721::Create(TestAddress);
+    
+    TestNotNull("Token should not be null", Token);
+    TestEqual("Contract address should match", Token->ContractAddress, TestAddress);
+    
+    return true;
+} 


### PR DESCRIPTION
…eate method for each of them so that they can be instantiated in a much less verbose way. Also added some basic unit tests to confirm that they are working correctly

This turns code like this:

```
UERC1155SaleContract* SaleContract = NewObject<UERC1155SaleContract>();
SaleContract->ContractAddress = TEXT("0xe65b75eb7c58ffc0bf0e671d64d0e1c6cd0d3e5b");
SaleContract->PaymentToken = TEXT("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359");
SaleContract->MaxTotal = 20000;
SaleContract->Data = TEXT("Minted using the Sequence Unreal SDK");
```
into this:
```
UERC1155SaleContract* SaleContract = UERC1155SaleContract::Create(
    TEXT("0xe65b75eb7c58ffc0bf0e671d64d0e1c6cd0d3e5b"),
    TEXT("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
    20000,
    TEXT("Minted using the Sequence Unreal SDK"));
```
which is much less error prone

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [ ] No documentation update is needed for this change.

There likely should be a docs update here, but I'm not sure where the best place would be to fit these in as we don't currently have any contract wrapper docs at the moment. I'm also unsure which subsystem these should live under. Any thoughts? Maybe we should add a Contracts subsystem and docs section?