### PR TITLE
Reverted file name from back to 'Cr'

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Util/CredentialsStorage.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Util/CredentialsStorage.h
@@ -22,6 +22,6 @@ private:
 	UPROPERTY()
 	UGenericNativeEncryptor* Encryptor = nullptr;
 	
-	const FString SaveSlot = "SequenceCredentials";
+	const FString SaveSlot = "Cr";
 	const uint32 UserIndex = 0;
 };


### PR DESCRIPTION
Reverting the change from a previous PR some days ago, because of the following: When existing projects use the newer version of the SDK, their players are suddenly asked to sign-in again, even if they have a valid session stored in the old file.

We could do such a change later, but I believe we need to think carefully how we keep the credentials file backward compatible.

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
