### PR TITLE
Instead of just migrating the save data and forcing any logged in use…

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Util/CredentialsStorage.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Util/CredentialsStorage.cpp
@@ -68,7 +68,7 @@ bool UCredentialsStorage::GetStoredCredentials(FCredentials_BE* Credentials) con
 
 	if (SaveGame == nullptr)
 	{
-		UGameplayStatics::LoadGameFromSlot(this->OldSaveSlot, this->UserIndex);
+		SaveGame = UGameplayStatics::LoadGameFromSlot(this->OldSaveSlot, this->UserIndex);
 	}
 
 	if (SaveGame != nullptr)

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Private/Util/CredentialsStorage.cpp
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Private/Util/CredentialsStorage.cpp
@@ -66,6 +66,11 @@ bool UCredentialsStorage::GetStoredCredentials(FCredentials_BE* Credentials) con
 	bool ret = false;
 	const USaveGame * SaveGame = UGameplayStatics::LoadGameFromSlot(this->SaveSlot, this->UserIndex);
 
+	if (SaveGame == nullptr)
+	{
+		UGameplayStatics::LoadGameFromSlot(this->OldSaveSlot, this->UserIndex);
+	}
+
 	if (SaveGame != nullptr)
 	{
 		if (const UStorableCredentials* LoadedCredentials = Cast<UStorableCredentials>(SaveGame))
@@ -88,6 +93,7 @@ bool UCredentialsStorage::GetStoredCredentials(FCredentials_BE* Credentials) con
 			{
 				SEQ_LOG(Error, TEXT("[System Failure: Unable to read save file or file is corrupted]"));
 				UGameplayStatics::DeleteGameInSlot(this->SaveSlot, this->UserIndex);
+				UGameplayStatics::DeleteGameInSlot(this->OldSaveSlot, this->UserIndex);
 			}
 		}
 	}

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Util/CredentialsStorage.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Util/CredentialsStorage.h
@@ -23,5 +23,6 @@ private:
 	UGenericNativeEncryptor* Encryptor = nullptr;
 	
 	const FString SaveSlot = "SequenceCredentials";
+	const FString OldSaveSlot = "Cr";
 	const uint32 UserIndex = 0;
 };


### PR DESCRIPTION
…rs to re-login, instead, still load from the old save file if we can't find it but only save to new path.

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
