### PR TITLE
Fixed ref param inside checkout bp delegate, added namespace to SequenceSdk.h

### DIFF
--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Sequence/SequenceSdk.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Sequence/SequenceSdk.h
@@ -5,7 +5,7 @@
 /*
  * Central class for any SDK configuration information.
  */
-class SequenceSdk
+class SEQUENCEPLUGIN_API SequenceSdk
 {
 public:
 	/**

--- a/Plugins/SequencePlugin/Source/SequencePlugin/Public/Subsystems/SequenceCheckoutBP.h
+++ b/Plugins/SequencePlugin/Source/SequencePlugin/Public/Subsystems/SequenceCheckoutBP.h
@@ -12,7 +12,7 @@ class SEQUENCEPLUGIN_API USequenceCheckoutBP : public UGameInstanceSubsystem
 
 public:
 	DECLARE_DYNAMIC_DELEGATE_OneParam(FOnGetCheckoutOptionsResponseSuccess, FCheckoutOptions, Options);
-	DECLARE_DYNAMIC_DELEGATE_OneParam(FOnGenerateTransactionResponseSuccess, TArray<FTransactionStep>, Steps);
+	DECLARE_DYNAMIC_DELEGATE_OneParam(FOnGenerateTransactionResponseSuccess, const TArray<FTransactionStep>&, Steps);
 	DECLARE_DYNAMIC_DELEGATE_OneParam(FOnCheckoutFailure, FString, Error);
 	
 	USequenceCheckoutBP();


### PR DESCRIPTION
Fixed error from an integration into a new project. SequenceSdk is not available in C++ without the namespace. The old CheckoutBP delegate TArray was having Blueprint compiler issues when using the Checkout subsystem

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
